### PR TITLE
`selectedIndex` => `selectedHash` for demo selection

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,7 +55,7 @@ body {
     <core-scaffold id="scaffold">
       <core-header-panel navigation flex mode="seamed">
         <core-toolbar>Web Animations</core-toolbar>
-        <core-menu theme="core-light-theme" selected={{selectedIndex}} on-core-select={{selectAction}}>
+        <core-menu theme="core-light-theme" selected={{selectedHash}} valueattr="label" on-core-select={{selectAction}}>
           <template repeat={{model}}>
             <core-item label={{name}} data-hash="{{hash}}"></core-item>
           </template>
@@ -92,7 +92,7 @@ body {
 <script>
 Polymer('web-animations-demos', {
   selected: null,
-  selectedIndex: null,
+  selectedHash: null,
   selectAction: function(e, detail) {
     if (detail.isSelected) {
       window.location.hash = detail.item.dataset.hash;
@@ -101,17 +101,20 @@ Polymer('web-animations-demos', {
   },
   hashchange: function() {
     var hash = window.location.hash;
-    this.selected = null;
+
     for (var i = 0; i < this.model.length; i++) {
-      if (this.model[i].hash == hash) {
-        this.selected = this.model[i];
-        this.selectedIndex = this.selected.index;
+      var demo = this.model[i];
+      if (demo.hash == hash) {
+        this.selected = demo;
+        this.selectedHash = demo.hash;
         return;
       }
     }
+
     if (!this.selected) {
-      this.selected = this.model[0];
-      this.selectedIndex = 0;
+      var defaultDemo = this.model[0];
+      this.selected = defaultDemo;
+      this.selectedHash = defaultDemo.hash;
     }
   },
   ready: function() {
@@ -124,8 +127,7 @@ Polymer('web-animations-demos', {
 <web-animations-demos></web-animations-demos>
 <script src="demos.js"></script>
 <script>
-function normalizeDemo(demo, i) {
-  demo.index = i;
+function normalizeDemo(demo) {
   if (!demo.path) {
     demo.path = demo.name.toLowerCase();
   }


### PR DESCRIPTION
Replace `selectedIndex` with `selectedHash`, which removes the requirement to assign every demo a specific index. The hash is also already required to be unique.

This makes selection easier to work with.