### PR TITLE
Fix syntax of viewport meta elements

### DIFF
--- a/animate_css/index.html
+++ b/animate_css/index.html
@@ -20,7 +20,7 @@ A Web Animations implementation of Animate.css which can be found here http://da
 <!DOCTYPE html>
 <html>
   <head>
-   <meta name="viewport" content="width=device-width, height=device-height, user-scalable=false">
+   <meta name="viewport" content="width=device-width, height=device-height, user-scalable=no">
     <link href="https://fonts.googleapis.com/css?family=RobotoDraft:300" rel="stylesheet" type="text/css">
     <script src="../polyfill-loader.js"></script>
     <style>

--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@ limitations under the License.
 
 <!DOCTYPE html>
 
-<meta name="viewport" content="width=device-width, height=device-height, user-scalable=false;">
+<meta name="viewport" content="width=device-width, height=device-height, user-scalable=no">
 
 <script src="components/webcomponentsjs/webcomponents.js"></script>
 <link href="https://fonts.googleapis.com/css?family=RobotoDraft:300" rel="stylesheet" type="text/css">


### PR DESCRIPTION
[Spec draft](https://drafts.csswg.org/css-device-adapt/#parsing-algorithm)

Relevant section regarding semi-colon vs. comma as comma separator:

> Authors should be using comma in order to ensure content works as expected in all UAs

Relevant section regarding how to represent a boolean false value:

> If the value can not be converted to a number as described above, the whole `property-value` string will be matched with the following strings case-insensitively: `yes`, `no`, `device-width`, `device-height`